### PR TITLE
Omit relationships between a course and itself

### DIFF
--- a/sis_scraper/sis_scraper.py
+++ b/sis_scraper/sis_scraper.py
@@ -120,6 +120,7 @@ async def process_class_details(
         attributes_data = attributes_task.result()
         restrictions_data = restrictions_task.result()
         prerequisites_data = prerequisites_task.result()
+        # TODO: Filter out self-references from prerequisites
         corequisites_data = corequisites_task.result()
         corequisites_data = list(
             filter(


### PR DESCRIPTION
## What?

This pull request changes the SIS scraper such that corequisite and crosslist relationships between a course and itself are omitted.

Closes #30.

## Why?

Previously, we were running into an error trying to insert values into the database due to ARTS 2700 having crosslists with its own sections. This is definitely not great for data integrity, but we're making this very quick fix for the sake of pushing a first deployment fast.

## How?

I added some filters to class corequisite and crosslist data.

## Testing?

```py
"""
Checks all JSON files in the current directory for self-relationships.
"""

import json
from pathlib import Path

for path in Path(__name__).parent.glob("*.json"):
    with open(path, "r", encoding="utf-8") as f:
        data = json.load(f)
    for subject_code, subject in data.items():
        for course_code, course in subject["courses"].items():
            details = course["course_detail"]
            for rel_type in ["corequisite", "crosslist"]:
                if course_code in details.get(rel_type, []):
                    print(f"{course_code} has a {rel_type} relationship to itself")
```

## Anything Else?

Have a nice day.