### PR TITLE
Fix maximum credits not being parsed correctly

### DIFF
--- a/sis_scraper/sis_scraper.py
+++ b/sis_scraper/sis_scraper.py
@@ -198,7 +198,9 @@ async def process_class_details(
         course_credits["min"], class_entry["creditHourLow"] or 0
     )
     course_credits["max"] = max(
-        course_credits["max"], class_entry["creditHourHigh"] or 0
+        course_credits["max"],
+        class_entry["creditHourLow"] or 0,
+        class_entry["creditHourHigh"] or 0,
     )
 
     course_sections = course_details["sections"]


### PR DESCRIPTION
## What?

This pull request introduces a fix for maximum course credit values being parsed incorrectly. Now, for courses that do not have a credit range, the maximum credit hours will match the minimum credit hours.

Closes #28.

## Why?

Some courses without a credit range only have a credit low and a `null` value for credit high. And credit high is seemingly only used for those with a credit range. However, the scraper previously assumed there would be a valid value for both fields and as a result, many courses in the scraped data had a non-zero minimum credit hours with a zero maximum credit hours. Obviously, this was not right.

## How?

I added exactly one statement to the scraper code.

## Testing?

I wrote a quick test script to parse newly scraped data for any minimum credit hours that were greater than their corresponding maximum credit hours. No errors were found after the fix.

## Anything Else?

Have a nice day.