### PR TITLE
Omit duplicate relationships between courses

### DIFF
--- a/sis_scraper/sis_scraper.py
+++ b/sis_scraper/sis_scraper.py
@@ -203,8 +203,8 @@ async def process_class_details(
         course_details["attributes"] = attributes_data
         course_details["restrictions"] = restrictions_data
         course_details["prerequisite"] = prerequisites_data
-        course_details["corequisite"] = corequisites_data
-        course_details["crosslist"] = crosslists_data
+        course_details["corequisite"] = list(set(corequisites_data))
+        course_details["crosslist"] = list(set(crosslists_data))
 
     course_details = course_data[course_code]["course_detail"]
 


### PR DESCRIPTION
## What?

This pull request introduces a simple adjustment in the SIS scraper's behavior, which omits duplicate corequisite and crosslist relationships between two courses.

Closes #33.

## Why?

See #33.

## How?

I converted the corequisite and crosslist lists of strings for each course into a set, then back into a list in order to remove duplicates.

## Testing?

All duplicate course relationships have been removed after running the scraper again over all years, and this is verified by successful runs of the JSON to SQL script as no database errors have appeared.

## Anything Else?

Have a nice day.